### PR TITLE
Add interactive Dash app for AI math visualizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+.venv/
+.DS_Store
+
+# Dash debug artifacts
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# AI Math Explorer
+
+An interactive [Dash](https://dash.plotly.com/) web app that illustrates core
+mathematical ideas behind three pillars of modern AI using elegant 3D
+visualisations:
+
+- **Machine learning** – manipulate a regression plane to understand how loss is
+  driven by residuals.
+- **Neural networks** – watch a shallow network combine nonlinear activations
+  to approximate a target surface.
+- **Transformers** – explore how scaled dot-product attention distributes focus
+  across a sequence.
+
+## Getting started
+
+1. Create and activate a virtual environment (recommended):
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Launch the Dash development server:
+   ```bash
+   python -m app.app
+   ```
+4. Open your browser at <http://127.0.0.1:8050> to interact with the
+   visualisations.
+
+The app is entirely client-side rendered, so you can modify the controls without
+reloading the page. Each plot can be rotated, zoomed and panned for different
+perspectives.
+
+## Project structure
+
+```
+app/
+├── __init__.py
+├── app.py           # Dash entry point and layout
+└── visualizations.py # Plotly figure factories for each concept
+README.md
+requirements.txt
+```
+
+## Development tips
+
+- The figures are designed to be deterministic so callbacks respond smoothly
+  without regenerating random data.
+- Feel free to extend the app with more tabs or controls to dive deeper into
+  additional AI maths topics.

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,341 @@
+"""Dash application presenting interactive 3D math visualizations for AI concepts."""
+from __future__ import annotations
+
+import dash
+from dash import Dash, Input, Output, dcc, html
+
+from . import visualizations
+
+ATTENTION_TOKENS = visualizations.get_attention_tokens()
+
+external_stylesheets = [
+    "https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600&display=swap",
+]
+
+app: Dash = dash.Dash(__name__, external_stylesheets=external_stylesheets)
+app.title = "AI Math Explorer"
+
+common_card_style = {
+    "background": "rgba(15, 18, 51, 0.65)",
+    "padding": "1.2rem",
+    "borderRadius": "18px",
+    "backdropFilter": "blur(6px)",
+    "boxShadow": "0 18px 42px rgba(0, 0, 0, 0.35)",
+    "border": "1px solid rgba(255, 255, 255, 0.08)",
+}
+
+
+def _slider_label(text: str) -> html.Div:
+    return html.Div(text, style={"marginBottom": "0.35rem", "fontWeight": 500})
+
+
+def _description(text: str) -> html.Div:
+    return html.Div(
+        text,
+        style={
+            "marginBottom": "0.9rem",
+            "lineHeight": "1.6",
+            "color": "#dbe7ff",
+        },
+    )
+
+
+app.layout = html.Div(
+    [
+        html.Div(
+            [
+                html.H1(
+                    "AI Math Explorer",
+                    style={
+                        "fontSize": "2.6rem",
+                        "letterSpacing": "0.04em",
+                        "marginBottom": "0.4rem",
+                    },
+                ),
+                html.P(
+                    (
+                        "Interactively explore the core mathematical ideas powering "
+                        "modern AI systems. Adjust parameters to see how equations "
+                        "shape model behaviour in real time."
+                    ),
+                    style={
+                        "maxWidth": "780px",
+                        "fontSize": "1.05rem",
+                        "color": "#c7d7ff",
+                        "lineHeight": "1.7",
+                    },
+                ),
+            ],
+            style={"marginBottom": "1.8rem"},
+        ),
+        dcc.Tabs(
+            id="concept-tabs",
+            value="ml",
+            children=[
+                dcc.Tab(
+                    label="Machine Learning",
+                    value="ml",
+                    style={"background": "rgba(12,14,40,0.7)", "color": "#97b6ff"},
+                    selected_style={
+                        "background": "rgba(30,34,68,0.95)",
+                        "color": "#ffffff",
+                        "fontWeight": 600,
+                    },
+                    children=[
+                        html.Div(
+                            [
+                                html.Div(
+                                    [
+                                        _description(
+                                            (
+                                                "Adjust the slope and intercept of a regression plane. Colors on the "
+                                                "data points show the magnitude of residual errors, highlighting "
+                                                "how optimisation aligns the plane with observations."
+                                            )
+                                        ),
+                                        _slider_label("Weight for feature x₁"),
+                                        dcc.Slider(
+                                            id="ml-weight1",
+                                            min=-3.0,
+                                            max=3.0,
+                                            step=0.1,
+                                            value=1.8,
+                                            marks={-3: "-3", 0: "0", 3: "3"},
+                                        ),
+                                        _slider_label("Weight for feature x₂"),
+                                        dcc.Slider(
+                                            id="ml-weight2",
+                                            min=-3.0,
+                                            max=3.0,
+                                            step=0.1,
+                                            value=-2.4,
+                                            marks={-3: "-3", 0: "0", 3: "3"},
+                                        ),
+                                        _slider_label("Bias term"),
+                                        dcc.Slider(
+                                            id="ml-bias",
+                                            min=-2.0,
+                                            max=2.0,
+                                            step=0.05,
+                                            value=-0.2,
+                                            marks={-2: "-2", 0: "0", 2: "2"},
+                                        ),
+                                    ],
+                                    style={
+                                        **common_card_style,
+                                        "flex": "1 1 320px",
+                                        "marginRight": "1.2rem",
+                                    },
+                                ),
+                                html.Div(
+                                    dcc.Graph(
+                                        id="ml-graph",
+                                        config={"displaylogo": False},
+                                        style={"height": "520px"},
+                                    ),
+                                    style={"flex": "2 1 520px"},
+                                ),
+                            ],
+                            style={
+                                "display": "flex",
+                                "flexWrap": "wrap",
+                                "gap": "1.2rem",
+                                "alignItems": "stretch",
+                            },
+                        )
+                    ],
+                ),
+                dcc.Tab(
+                    label="Neural Networks",
+                    value="nn",
+                    style={"background": "rgba(12,14,40,0.7)", "color": "#97b6ff"},
+                    selected_style={
+                        "background": "rgba(30,34,68,0.95)",
+                        "color": "#ffffff",
+                        "fontWeight": 600,
+                    },
+                    children=[
+                        html.Div(
+                            [
+                                html.Div(
+                                    [
+                                        _description(
+                                            (
+                                                "Visualise how a shallow neural network stitches together nonlinear "
+                                                "basis functions. Tune the number of hidden units, the activation "
+                                                "sharpness and the output scaling to see the approximation evolve."
+                                            )
+                                        ),
+                                        _slider_label("Hidden units"),
+                                        dcc.Slider(
+                                            id="nn-hidden",
+                                            min=3,
+                                            max=9,
+                                            step=1,
+                                            value=6,
+                                            marks={i: str(i) for i in range(3, 10)},
+                                        ),
+                                        _slider_label("Activation scale"),
+                                        dcc.Slider(
+                                            id="nn-activation",
+                                            min=0.6,
+                                            max=2.6,
+                                            step=0.1,
+                                            value=1.3,
+                                            marks={0.6: "0.6", 1.6: "1.6", 2.6: "2.6"},
+                                        ),
+                                        _slider_label("Output scale"),
+                                        dcc.Slider(
+                                            id="nn-output",
+                                            min=0.3,
+                                            max=2.0,
+                                            step=0.05,
+                                            value=1.0,
+                                            marks={0.3: "0.3", 1.0: "1.0", 2.0: "2.0"},
+                                        ),
+                                    ],
+                                    style={
+                                        **common_card_style,
+                                        "flex": "1 1 320px",
+                                        "marginRight": "1.2rem",
+                                    },
+                                ),
+                                html.Div(
+                                    dcc.Graph(
+                                        id="nn-graph",
+                                        config={"displaylogo": False},
+                                        style={"height": "520px"},
+                                    ),
+                                    style={"flex": "2 1 520px"},
+                                ),
+                            ],
+                            style={
+                                "display": "flex",
+                                "flexWrap": "wrap",
+                                "gap": "1.2rem",
+                                "alignItems": "stretch",
+                            },
+                        )
+                    ],
+                ),
+                dcc.Tab(
+                    label="Transformers",
+                    value="transformers",
+                    style={"background": "rgba(12,14,40,0.7)", "color": "#97b6ff"},
+                    selected_style={
+                        "background": "rgba(30,34,68,0.95)",
+                        "color": "#ffffff",
+                        "fontWeight": 600,
+                    },
+                    children=[
+                        html.Div(
+                            [
+                                html.Div(
+                                    [
+                                        _description(
+                                            (
+                                                "Scaled dot-product attention turns contextual similarity into a "
+                                                "probability distribution. Alter the softmax temperature to see the "
+                                                "focus sharpen or diffuse, and select a query token to track its row."
+                                            )
+                                        ),
+                                        _slider_label("Softmax temperature"),
+                                        dcc.Slider(
+                                            id="attn-temperature",
+                                            min=0.4,
+                                            max=2.4,
+                                            step=0.05,
+                                            value=1.0,
+                                            marks={0.4: "0.4", 1.0: "1.0", 2.4: "2.4"},
+                                        ),
+                                        _slider_label("Focused query token"),
+                                        dcc.Slider(
+                                            id="attn-query",
+                                            min=0,
+                                            max=len(ATTENTION_TOKENS) - 1,
+                                            step=1,
+                                            value=3,
+                                            marks={
+                                                i: token
+                                                for i, token in enumerate(ATTENTION_TOKENS)
+                                            },
+                                        ),
+                                    ],
+                                    style={
+                                        **common_card_style,
+                                        "flex": "1 1 320px",
+                                        "marginRight": "1.2rem",
+                                    },
+                                ),
+                                html.Div(
+                                    dcc.Graph(
+                                        id="attn-graph",
+                                        config={"displaylogo": False},
+                                        style={"height": "520px"},
+                                    ),
+                                    style={"flex": "2 1 520px"},
+                                ),
+                            ],
+                            style={
+                                "display": "flex",
+                                "flexWrap": "wrap",
+                                "gap": "1.2rem",
+                                "alignItems": "stretch",
+                            },
+                        )
+                    ],
+                ),
+            ],
+            style={
+                "background": "rgba(22, 26, 66, 0.95)",
+                "borderRadius": "24px",
+                "overflow": "hidden",
+                "boxShadow": "0 20px 45px rgba(0, 0, 0, 0.45)",
+            },
+        ),
+    ],
+    style={
+        "background": "radial-gradient(circle at top, #1a1d4b, #080a1f 65%)",
+        "color": "white",
+        "minHeight": "100vh",
+        "padding": "3rem",
+        "fontFamily": "'Space Grotesk', sans-serif",
+    },
+)
+
+
+@app.callback(
+    Output("ml-graph", "figure"),
+    Input("ml-weight1", "value"),
+    Input("ml-weight2", "value"),
+    Input("ml-bias", "value"),
+)
+def update_linear_regression(weight1: float, weight2: float, bias: float):
+    return visualizations.create_linear_regression_figure(weight1, weight2, bias)
+
+
+@app.callback(
+    Output("nn-graph", "figure"),
+    Input("nn-hidden", "value"),
+    Input("nn-activation", "value"),
+    Input("nn-output", "value"),
+)
+def update_neural_network(hidden_units: int, activation_scale: float, output_scale: float):
+    return visualizations.create_neural_network_figure(
+        hidden_units=int(hidden_units),
+        activation_scale=activation_scale,
+        output_scale=output_scale,
+    )
+
+
+@app.callback(
+    Output("attn-graph", "figure"),
+    Input("attn-temperature", "value"),
+    Input("attn-query", "value"),
+)
+def update_attention(temperature: float, query_index: int):
+    return visualizations.create_attention_figure(float(temperature), int(query_index))
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/app/visualizations.py
+++ b/app/visualizations.py
@@ -1,0 +1,283 @@
+"""Reusable Plotly visualizations for the interactive AI math explorer app."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Tuple
+
+import numpy as np
+import plotly.graph_objects as go
+
+
+# --- Machine learning: linear regression plane ---------------------------------
+
+
+@lru_cache(maxsize=1)
+def _regression_dataset(
+    n_points: int = 80,
+    noise: float = 1.1,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Generate and cache a synthetic linear regression dataset.
+
+    The random seed is fixed so that the dataset remains stable across callback
+    executions, keeping the interaction smooth and reproducible.
+    """
+
+    rng = np.random.default_rng(seed=21)
+    x1 = rng.uniform(-4.0, 4.0, size=n_points)
+    x2 = rng.uniform(-4.0, 4.0, size=n_points)
+    true_weights = np.array([1.8, -2.4])
+    true_bias = -0.2
+    y = (
+        true_weights[0] * x1
+        + true_weights[1] * x2
+        + true_bias
+        + rng.normal(0.0, noise, size=n_points)
+    )
+    return x1, x2, y
+
+
+def create_linear_regression_figure(
+    weight_x1: float,
+    weight_x2: float,
+    bias: float,
+) -> go.Figure:
+    """Return an interactive 3D view of a regression plane versus the data."""
+
+    x1, x2, y = _regression_dataset()
+
+    x_range = np.linspace(x1.min() - 1.0, x1.max() + 1.0, 40)
+    y_range = np.linspace(x2.min() - 1.0, x2.max() + 1.0, 40)
+    grid_x1, grid_x2 = np.meshgrid(x_range, y_range)
+    plane = weight_x1 * grid_x1 + weight_x2 * grid_x2 + bias
+
+    predictions = weight_x1 * x1 + weight_x2 * x2 + bias
+    residuals = y - predictions
+    residual_magnitude = np.abs(residuals)
+
+    scatter = go.Scatter3d(
+        x=x1,
+        y=x2,
+        z=y,
+        mode="markers",
+        marker=dict(
+            size=6,
+            color=residual_magnitude,
+            colorscale="Turbo",
+            colorbar=dict(title="|residual|"),
+            opacity=0.8,
+        ),
+        hovertemplate=
+        "x₁: %{x:.2f}<br>x₂: %{y:.2f}<br>target: %{z:.2f}<br>"
+        "residual: %{marker.color:.2f}<extra></extra>",
+        name="observations",
+    )
+
+    plane_surface = go.Surface(
+        x=grid_x1,
+        y=grid_x2,
+        z=plane,
+        opacity=0.68,
+        colorscale="Viridis",
+        showscale=False,
+        name="regression plane",
+    )
+
+    fig = go.Figure(data=[plane_surface, scatter])
+    fig.update_layout(
+        title="Interactive linear regression",
+        scene=dict(
+            xaxis_title="feature x₁",
+            yaxis_title="feature x₂",
+            zaxis_title="prediction",
+            aspectmode="cube",
+            xaxis=dict(backgroundcolor="rgba(10,10,30,0.15)"),
+            yaxis=dict(backgroundcolor="rgba(10,10,30,0.15)"),
+            zaxis=dict(backgroundcolor="rgba(10,10,30,0.05)"),
+        ),
+        margin=dict(l=0, r=0, b=0, t=50),
+        template="plotly_dark",
+    )
+    return fig
+
+
+# --- Neural network: feed-forward surface approximation ------------------------
+
+
+@lru_cache(maxsize=1)
+def _network_weights(max_hidden: int = 9) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Create deterministic base weights for a tiny fully-connected network."""
+
+    rng = np.random.default_rng(seed=7)
+    w1 = rng.normal(scale=0.9, size=(2, max_hidden))
+    b1 = rng.normal(scale=0.4, size=(max_hidden,))
+    w2 = rng.normal(scale=0.6, size=(max_hidden,))
+    return w1, b1, w2
+
+
+def _target_surface(x: np.ndarray, y: np.ndarray) -> np.ndarray:
+    """Smooth target function that the neural net aims to mimic."""
+
+    return np.sin(x) * np.cos(y) + 0.25 * np.cos(2 * x + y)
+
+
+def create_neural_network_figure(
+    hidden_units: int,
+    activation_scale: float,
+    output_scale: float,
+) -> go.Figure:
+    """Render the neural network output surface alongside the target function."""
+
+    w1, b1, w2 = _network_weights()
+    grid = np.linspace(-2.5, 2.5, 60)
+    mesh_x, mesh_y = np.meshgrid(grid, grid)
+    flat_inputs = np.stack([mesh_x.ravel(), mesh_y.ravel()], axis=1)
+
+    w1_scaled = w1[:, :hidden_units] * activation_scale
+    b1_scaled = b1[:hidden_units] * activation_scale
+    hidden = np.tanh(flat_inputs @ w1_scaled + b1_scaled)
+    predictions = hidden @ (w2[:hidden_units] * output_scale)
+    surface = predictions.reshape(mesh_x.shape)
+
+    target = _target_surface(mesh_x, mesh_y)
+
+    network_surface = go.Surface(
+        x=mesh_x,
+        y=mesh_y,
+        z=surface,
+        colorscale="Inferno",
+        opacity=0.92,
+        showscale=False,
+        name="network output",
+    )
+
+    target_surface = go.Surface(
+        x=mesh_x,
+        y=mesh_y,
+        z=target,
+        colorscale="Blues",
+        showscale=False,
+        opacity=0.35,
+        name="target function",
+    )
+
+    fig = go.Figure(data=[target_surface, network_surface])
+    fig.update_layout(
+        title="Neural network function approximation",
+        scene=dict(
+            xaxis_title="input x₁",
+            yaxis_title="input x₂",
+            zaxis_title="output",
+            aspectmode="cube",
+        ),
+        margin=dict(l=0, r=0, b=0, t=50),
+        template="plotly_dark",
+    )
+    return fig
+
+
+# --- Transformers: attention distribution --------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _attention_components() -> Tuple[Tuple[str, ...], np.ndarray, np.ndarray]:
+    """Create deterministic token embeddings and projection matrices."""
+
+    tokens = (
+        "[CLS]",
+        "A",
+        "curious",
+        "robot",
+        "learns",
+        "math",
+        "today",
+        "[SEP]",
+    )
+    rng = np.random.default_rng(seed=19)
+    base_embeddings = rng.normal(scale=0.9, size=(len(tokens), 5))
+    wq = rng.normal(scale=0.7, size=(5, 5))
+    wk = rng.normal(scale=0.7, size=(5, 5))
+
+    queries = base_embeddings @ wq
+    keys = base_embeddings @ wk
+    return tokens, queries, keys
+
+
+def _softmax(values: np.ndarray, axis: int = -1) -> np.ndarray:
+    shifted = values - np.max(values, axis=axis, keepdims=True)
+    exp = np.exp(shifted)
+    return exp / np.sum(exp, axis=axis, keepdims=True)
+
+
+def get_attention_tokens() -> Tuple[str, ...]:
+    """Return the ordered list of tokens used in the attention demo."""
+
+    tokens, _, _ = _attention_components()
+    return tokens
+
+
+def create_attention_figure(temperature: float, focus_query: int) -> go.Figure:
+    """Visualize scaled dot-product attention as a 3D surface."""
+
+    tokens, queries, keys = _attention_components()
+    scores = (queries @ keys.T) / temperature
+    weights = _softmax(scores, axis=-1)
+
+    x_indices = np.arange(len(tokens))
+    y_indices = np.arange(len(tokens))
+    mesh_x, mesh_y = np.meshgrid(x_indices, y_indices)
+    hover_text = np.array(
+        [
+            [
+                f"query: {tokens[q]}<br>key: {tokens[k]}"
+                for k in x_indices
+            ]
+            for q in y_indices
+        ]
+    )
+
+    surface = go.Surface(
+        x=mesh_x,
+        y=mesh_y,
+        z=weights,
+        colorscale="Viridis",
+        opacity=0.9,
+        name="attention weights",
+        showscale=True,
+        colorbar=dict(title="attention"),
+        text=hover_text,
+        hovertemplate="%{text}<br>weight: %{z:.3f}<extra></extra>",
+    )
+
+    highlight_row = go.Scatter3d(
+        x=x_indices,
+        y=np.full_like(x_indices, focus_query),
+        z=weights[focus_query],
+        mode="lines+markers",
+        line=dict(color="#00F5FF", width=6),
+        marker=dict(size=6, color="#00F5FF"),
+        name=f"focus: {tokens[focus_query]}",
+        text=[tokens[i] for i in x_indices],
+        hovertemplate="key token: %{text}<br>attention: %{z:.3f}<extra></extra>",
+    )
+
+    fig = go.Figure(data=[surface, highlight_row])
+    fig.update_layout(
+        title="Transformer scaled dot-product attention",
+        scene=dict(
+            xaxis=dict(
+                title="key positions",
+                tickvals=x_indices,
+                ticktext=tokens,
+            ),
+            yaxis=dict(
+                title="query positions",
+                tickvals=y_indices,
+                ticktext=tokens,
+            ),
+            zaxis=dict(title="weight"),
+            aspectratio=dict(x=1.1, y=1.1, z=0.6),
+        ),
+        margin=dict(l=0, r=0, b=0, t=50),
+        template="plotly_dark",
+    )
+    return fig

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+dash>=2.16
+plotly>=5.19
+numpy>=1.24


### PR DESCRIPTION
## Summary
- create a polished Dash interface with tabs for machine learning, neural networks, and transformer attention demos
- implement reusable Plotly figure factories with deterministic synthetic data for each concept
- document setup steps and dependencies for running the AI Math Explorer app

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d3d4c635fc832782c2ddd91c055b99